### PR TITLE
chore: Rename project to Git Friday

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# Git Digest
+# Git Friday
 
 An intelligent CLI tool that uses AI to analyze git commits and generate a clear, human-readable report. It helps team leads and managers quickly understand the progress made by developers without digging through technical commit logs.
 
 ## Installation
 
-You can install Git Digest globally using your preferred package manager:
+You can install Git Friday globally using your preferred package manager:
 
 ### npm
 ```bash
-npm install -g @stas_fr/git-digest
+npm install -g @stas_fr/git-friday
 ```
 
 ### pnpm
 ```bash
-pnpm add -g @stas_fr/git-digest
+pnpm add -g @stas_fr/git-friday
 ```
 
 ### yarn
 ```bash
-yarn global add @stas_fr/git-digest
+yarn global add @stas_fr/git-friday
 ```
 
 ## Usage
@@ -47,7 +47,7 @@ The main command is `generate`. It accepts the following parameters:
 Here is an example of how to run the command:
 
 ```bash
-gtc generate -a s.farkash stas_fr -b dev main
+friday generate -a s.farkash stas_fr -b dev main
 ```
 
 This command will search for all commits made today by the authors `s.farkash` and `stas_fr` within the `dev` and `main` branches, and then generate a consolidated report based on them.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@stas_fr/git-digest",
+  "name": "git-friday",
   "version": "0.8.0",
   "description": "An intelligent CLI tool that uses AI to analyze git commits and generate a clear, human-readable report.",
   "main": "dist/src/cli/index.js",
   "type": "module",
   "bin": {
-    "gtc": "dist/src/cli/index.js"
+    "friday": "dist/src/cli/index.js"
   },
   "files": [
     "dist",
@@ -40,13 +40,13 @@
     "url": "https://stasfr.ru/"
   },
   "license": "MIT",
-  "homepage": "https://github.com/stasfr/git-digest#readme",
+  "homepage": "https://github.com/stasfr/git-friday#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stasfr/git-digest.git"
+    "url": "git+https://github.com/stasfr/git-friday.git"
   },
   "bugs": {
-    "url": "https://github.com/stasfr/git-digest/issues"
+    "url": "https://github.com/stasfr/git-friday/issues"
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
   "dependencies": {


### PR DESCRIPTION
- Update package name from @stas_fr/git-digest to git-friday
- Change CLI command from gtc to friday
- Update all documentation references and repository URLs